### PR TITLE
Allowed shipping options support and small bug fixing

### DIFF
--- a/Nop.Plugin.Shipping.ShipStation/Controllers/ShipStationController.cs
+++ b/Nop.Plugin.Shipping.ShipStation/Controllers/ShipStationController.cs
@@ -58,7 +58,8 @@ namespace Nop.Plugin.Shipping.ShipStation.Controllers
                 ActiveStoreScopeConfiguration = storeScope,
                 UserName = shipStationSettings.UserName,
                 Password = shipStationSettings.Password,
-                WebhookURL = $"{_webHelper.GetStoreLocation()}Plugins/ShipStation/Webhook"
+                WebhookURL = $"{_webHelper.GetStoreLocation()}Plugins/ShipStation/Webhook",
+                AllowedShippingOptions = shipStationSettings.AllowedShippingOptions
             };
 
             if (storeScope <= 0)
@@ -71,6 +72,7 @@ namespace Nop.Plugin.Shipping.ShipStation.Controllers
             model.SendDimensio_OverrideForStore = _settingService.SettingExists(shipStationSettings, x => x.SendDimensio, storeScope);
             model.Password_OverrideForStore = _settingService.SettingExists(shipStationSettings, x => x.Password, storeScope);
             model.UserName_OverrideForStore = _settingService.SettingExists(shipStationSettings, x => x.UserName, storeScope);
+            model.AllowedShippingOptions_OverrideForStore = _settingService.SettingExists(shipStationSettings, x => x.AllowedShippingOptions, storeScope);
 
             return View("~/Plugins/Shipping.ShipStation/Views/Configure.cshtml", model);
         }
@@ -95,6 +97,7 @@ namespace Nop.Plugin.Shipping.ShipStation.Controllers
             shipStationSettings.SendDimensio = model.SendDimensio;
             shipStationSettings.Password = model.Password;
             shipStationSettings.UserName = model.UserName;
+            shipStationSettings.AllowedShippingOptions = model.AllowedShippingOptions;
 
             /* We do not clear cache after each setting update.
              * This behavior can increase performance because cached settings will not be cleared 
@@ -106,6 +109,7 @@ namespace Nop.Plugin.Shipping.ShipStation.Controllers
             _settingService.SaveSettingOverridablePerStore(shipStationSettings, x => x.SendDimensio, model.SendDimensio_OverrideForStore, storeScope, false);
             _settingService.SaveSettingOverridablePerStore(shipStationSettings, x => x.Password, model.Password_OverrideForStore, storeScope, false);
             _settingService.SaveSettingOverridablePerStore(shipStationSettings, x => x.UserName, model.UserName_OverrideForStore, storeScope, false);
+            _settingService.SaveSettingOverridablePerStore(shipStationSettings, x => x.AllowedShippingOptions, model.AllowedShippingOptions_OverrideForStore, storeScope, false);
 
             //now clear settings cache
             _settingService.ClearCache();

--- a/Nop.Plugin.Shipping.ShipStation/Models/ShipStationModel.cs
+++ b/Nop.Plugin.Shipping.ShipStation/Models/ShipStationModel.cs
@@ -39,6 +39,10 @@ namespace Nop.Plugin.Shipping.ShipStation.Models
         public string Password { get; set; }
         public bool Password_OverrideForStore { get; set; }
 
+        [NopResourceDisplayName("Plugins.Shipping.ShipStation.Fields.AllowedShippingOptions")]
+        public string AllowedShippingOptions { get; set; }
+        public bool AllowedShippingOptions_OverrideForStore { get; set; }
+
         public string WebhookURL { get; set; }
     }
 }

--- a/Nop.Plugin.Shipping.ShipStation/Nop.Plugin.Shipping.ShipStation.csproj
+++ b/Nop.Plugin.Shipping.ShipStation/Nop.Plugin.Shipping.ShipStation.csproj
@@ -10,6 +10,10 @@
     <RepositoryType>Git</RepositoryType>
 	  <OutputPath>..\..\Presentation\Nop.Web\Plugins\Shipping.ShipStation</OutputPath>
     <OutDir>$(OutputPath)</OutDir>
+    <!--Set this parameter to true to get the dlls copied from the NuGet cache to the output of your project.
+    You need to set this parameter to true if your plugin has a nuget package 
+    to ensure that the dlls copied from the NuGet cache to the output of your project-->
+    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   
   <ItemGroup>
@@ -31,8 +35,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Presentation\Nop.Web.Framework\Nop.Web.Framework.csproj" />
-    <ProjectReference Include="..\..\Presentation\Nop.Web\Nop.Web.csproj" />
+    <ProjectReference Include="..\..\Presentation\Nop.Web\Nop.Web.csproj">
+      <Private>false</Private>
+    </ProjectReference>
     <ClearPluginAssemblies Include="$(MSBuildProjectDirectory)\..\..\Build\ClearPluginAssemblies.proj" />
   </ItemGroup>
 

--- a/Nop.Plugin.Shipping.ShipStation/ShipStationSettings.cs
+++ b/Nop.Plugin.Shipping.ShipStation/ShipStationSettings.cs
@@ -38,5 +38,10 @@ namespace Nop.Plugin.Shipping.ShipStation
         /// ShipStation password
         /// </summary>
         public string Password { get; set; }
+
+        /// <summary>
+        /// Allowed ShipStation shipping options (comma separated)
+        /// </summary>
+        public string AllowedShippingOptions { get; set; }
     }
 }

--- a/Nop.Plugin.Shipping.ShipStation/Views/Configure.cshtml
+++ b/Nop.Plugin.Shipping.ShipStation/Views/Configure.cshtml
@@ -11,7 +11,7 @@
     <div class="panel-group">
         <div class="panel panel-default">
             <div class="panel-body">
-                
+
                 <h3>Setup Instructions</h3>
                 <ul>
                     <li>Register or login on the <strong><a href="https://www.shipstation.com/?ref=partner-nopcommerce&utm_campaign=partner-referrals&utm_source=nopcommerce&utm_medium=partner-referral" target="_blank">ShipStation</a></strong> site</li>
@@ -26,76 +26,86 @@
                     <li>On the ShipStation form press Test your connection using the <strong>Test Connection</strong> button</li>
                     <li>Save the settings using the <strong>Connect</strong> button</li>
                 </ul>
-                <hr/>
+                <hr />
                 <div class="form-group">
                     <div class="col-md-3">
-                        <nop-override-store-checkbox asp-for="ApiKey" asp-input="ApiKey" asp-store-scope="@Model.ActiveStoreScopeConfiguration"/>
-                        <nop-label asp-for="ApiKey"/>
+                        <nop-override-store-checkbox asp-for="ApiKey_OverrideForStore" asp-input="ApiKey" asp-store-scope="@Model.ActiveStoreScopeConfiguration" />
+                        <nop-label asp-for="ApiKey" />
                     </div>
                     <div class="col-md-9">
-                        <nop-editor asp-for="ApiKey"/>
+                        <nop-editor asp-for="ApiKey" />
                         <span asp-validation-for="ApiKey"></span>
                     </div>
                 </div>
                 <div class="form-group">
                     <div class="col-md-3">
-                        <nop-override-store-checkbox asp-for="ApiSecret" asp-input="ApiSecret" asp-store-scope="@Model.ActiveStoreScopeConfiguration"/>
-                        <nop-label asp-for="ApiSecret"/>
+                        <nop-override-store-checkbox asp-for="ApiSecret_OverrideForStore" asp-input="ApiSecret" asp-store-scope="@Model.ActiveStoreScopeConfiguration" />
+                        <nop-label asp-for="ApiSecret" />
                     </div>
                     <div class="col-md-9">
-                        <nop-editor asp-for="ApiSecret"/>
+                        <nop-editor asp-for="ApiSecret" />
                         <span asp-validation-for="ApiSecret"></span>
                     </div>
                 </div>
 
                 <div class="form-group">
                     <div class="col-md-3">
-                        <nop-override-store-checkbox asp-for="UserName" asp-input="UserName" asp-store-scope="@Model.ActiveStoreScopeConfiguration"/>
-                        <nop-label asp-for="UserName"/>
+                        <nop-override-store-checkbox asp-for="UserName_OverrideForStore" asp-input="UserName" asp-store-scope="@Model.ActiveStoreScopeConfiguration" />
+                        <nop-label asp-for="UserName" />
                     </div>
                     <div class="col-md-9">
-                        <nop-editor asp-for="UserName"/>
+                        <nop-editor asp-for="UserName" />
                         <span asp-validation-for="UserName"></span>
                     </div>
                 </div>
                 <div class="form-group">
                     <div class="col-md-3">
-                        <nop-override-store-checkbox asp-for="Password" asp-input="Password" asp-store-scope="@Model.ActiveStoreScopeConfiguration"/>
-                        <nop-label asp-for="Password"/>
+                        <nop-override-store-checkbox asp-for="Password_OverrideForStore" asp-input="Password" asp-store-scope="@Model.ActiveStoreScopeConfiguration" />
+                        <nop-label asp-for="Password" />
                     </div>
                     <div class="col-md-9">
-                        <nop-editor asp-for="Password" asp-value="@Model.Password"/>
+                        <nop-editor asp-for="Password" asp-value="@Model.Password" />
                         <span asp-validation-for="Password"></span>
                     </div>
                 </div>
 
                 <div class="form-group">
                     <div class="col-md-3">
-                        <nop-override-store-checkbox asp-for="SendDimensio" asp-input="SendDimensio" asp-store-scope="@Model.ActiveStoreScopeConfiguration"/>
-                        <nop-label asp-for="SendDimensio"/>
+                        <nop-override-store-checkbox asp-for="SendDimensio_OverrideForStore" asp-input="SendDimensio" asp-store-scope="@Model.ActiveStoreScopeConfiguration" />
+                        <nop-label asp-for="SendDimensio" />
                     </div>
                     <div class="col-md-9">
-                        <nop-editor asp-for="SendDimensio"/>
+                        <nop-editor asp-for="SendDimensio" />
                         <span asp-validation-for="SendDimensio"></span>
                     </div>
                 </div>
                 <div class="form-group" id="pnlPackingType">
                     <div class="col-md-3">
-                        <nop-override-store-checkbox asp-for="PackingType" asp-input="PackingType" asp-store-scope="@Model.ActiveStoreScopeConfiguration"/>
-                        <nop-label asp-for="PackingTypeValues"/>
+                        <nop-override-store-checkbox asp-for="PackingType_OverrideForStore" asp-input="PackingType" asp-store-scope="@Model.ActiveStoreScopeConfiguration" />
+                        <nop-label asp-for="PackingTypeValues" />
                     </div>
                     <div class="col-md-9">
-                        <nop-select asp-for="PackingType" asp-items="Model.PackingTypeValues"/>
+                        <nop-select asp-for="PackingType" asp-items="Model.PackingTypeValues" />
                     </div>
                 </div>
                 <div class="form-group" id="pnlPackingPackageVolume">
                     <div class="col-md-3">
-                        <nop-override-store-checkbox asp-for="PackingPackageVolume" asp-input="PackingPackageVolume" asp-store-scope="@Model.ActiveStoreScopeConfiguration"/>
-                        <nop-label asp-for="PackingPackageVolume"/>
+                        <nop-override-store-checkbox asp-for="PackingPackageVolume_OverrideForStore" asp-input="PackingPackageVolume" asp-store-scope="@Model.ActiveStoreScopeConfiguration" />
+                        <nop-label asp-for="PackingPackageVolume" />
                     </div>
                     <div class="col-md-9">
-                        <nop-editor asp-for="PackingPackageVolume"/>
+                        <nop-editor asp-for="PackingPackageVolume" />
                         <span asp-validation-for="PackingPackageVolume"></span>
+                    </div>
+                </div>
+                <div class="form-group" id="pnlAllowedShippingOptions">
+                    <div class="col-md-3">
+                        <nop-override-store-checkbox asp-for="AllowedShippingOptions_OverrideForStore" asp-input="AllowedShippingOptions" asp-store-scope="@Model.ActiveStoreScopeConfiguration" />
+                        <nop-label asp-for="AllowedShippingOptions" />
+                    </div>
+                    <div class="col-md-9">
+                        <nop-textarea asp-for="AllowedShippingOptions" />
+                        <span asp-validation-for="AllowedShippingOptions"></span>
                     </div>
                 </div>
 
@@ -105,7 +115,7 @@
                         &nbsp;
                     </div>
                     <div class="col-md-9">
-                        <input type="submit" name="save" class="btn bg-blue" value="@T("Admin.Common.Save")"/>
+                        <input type="submit" name="save" class="btn bg-blue" value="@T("Admin.Common.Save")" />
                     </div>
                 </div>
 


### PR DESCRIPTION
- Do not copy Nop.Web binary files to the plugin's build folder
- Fixed bug  when the plugin is used for multi-store installation (property override checkbox)
- Added a property to filter out allowed shipping options